### PR TITLE
Migrate from bintray to GitHub Packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -14,17 +14,18 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        java: [1.8, 11.x.x, 12.x.x]
+        java: [11.x.x, 12.x.x, 15.x.x]
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'zulu'
           java-version: ${{ matrix.java}}
       - name: Cache the dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -33,6 +34,6 @@ jobs:
       - name: Build with Maven
         run: mvn -B package --file pom.xml
       - name: Upload the coverage report
-        uses: codecov/codecov-action@v1.0.5
+        uses: codecov/codecov-action@v2
         with:
           token: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish snapshot to GitHub Packages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 11
+      - name: Cache the dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Publish package
+        run: mvn --batch-mode release:prepare release:perform
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,5 @@
 ![Build Status](https://img.shields.io/github/workflow/status/thepieterdc/random-java/Java)
 [![codecov](https://codecov.io/gh/thepieterdc/random-java/branch/master/graph/badge.svg)](https://codecov.io/gh/thepieterdc/random-java)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/b458bc137c2e4c309a29840d03e4f2ad)](https://www.codacy.com/manual/thepieterdc/random-java)
-[![Download](https://api.bintray.com/packages/thepieterdc/random-java/random-java/images/download.svg)](https://bintray.com/thepieterdc/random-java/random-java/_latestVersion)
 
 A Java library for generating random values.

--- a/pom.xml
+++ b/pom.xml
@@ -37,18 +37,15 @@
         <url>https://github.com/thepieterdc/random-java</url>
     </issueManagement>
 
-    <ciManagement>
-        <system>TravisCI</system>
-        <url>https://travis.com/thepieterdc/random-java</url>
-    </ciManagement>
-
     <properties>
-        <jdk.version>1.8</jdk.version>
-        <junit.version>4.13.1</junit.version>
-        <maven.compiler.version>3.8.0</maven.compiler.version>
-        <maven.jar.version>3.1.0</maven.jar.version>
-        <maven.javadoc.version>3.1.0</maven.javadoc.version>
-        <maven.source.version>3.0.1</maven.source.version>
+        <jacoco.version>0.8.7</jacoco.version>
+        <jdk.version>11</jdk.version>
+        <junit.version>4.13.2</junit.version>
+        <maven.compiler.version>3.8.1</maven.compiler.version>
+        <maven.jar.version>3.2.0</maven.jar.version>
+        <maven.javadoc.version>3.3.0</maven.javadoc.version>
+        <maven.release.version>3.0.0-M4</maven.release.version>
+        <maven.source.version>3.2.1</maven.source.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -104,7 +101,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.2</version>
+                    <version>${jacoco.version}</version>
                     <executions>
                         <execution>
                             <goals>
@@ -126,7 +123,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.2</version>
+                <version>${jacoco.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -145,7 +142,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>${maven.release.version}</version>
                 <configuration>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
                 </configuration>
@@ -155,9 +152,9 @@
 
     <distributionManagement>
         <repository>
-            <id>bintray-thepieterdc-random-java</id>
-            <name>thepieterdc-random-java</name>
-            <url>https://api.bintray.com/maven/thepieterdc/random-java/random-java/;publish=1</url>
+            <id>github</id>
+            <name>GitHub Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/thepieterdc/random-java</url>
         </repository>
     </distributionManagement>
 </project>


### PR DESCRIPTION
Now that Bintray has stopped functioning, move this package over to GitHub Packages instead.